### PR TITLE
Fix initialization of req's next pointer in the FLL model

### DIFF
--- a/models/pulp/fll/fll_v1_impl.cpp
+++ b/models/pulp/fll/fll_v1_impl.cpp
@@ -334,6 +334,7 @@ vp::io_req_status_e fll::req(void *__this, vp::io_req *req)
     _this->first_pending = req;
 
   _this->last_pending = req;
+  req->set_next(NULL);
 
   return vp::IO_REQ_PENDING;
 }


### PR DESCRIPTION
A `vp::io_req`'s `next` pointer was not initialized to `NULL`, which lead to segmentation faults in the FLL model.